### PR TITLE
3-@Module_@Binds_and_@BindsInstance_annotations

### DIFF
--- a/app/src/main/java/com/example/android/dagger/di/AppComponent.kt
+++ b/app/src/main/java/com/example/android/dagger/di/AppComponent.kt
@@ -1,10 +1,17 @@
 package com.example.android.dagger.di
 
+import android.content.Context
 import com.example.android.dagger.registration.RegistrationActivity
+import dagger.BindsInstance
 import dagger.Component
 
-@Component
+@Component(modules = [StorageModule::class])
 interface AppComponent {
+
+    @Component.Factory
+    interface Factory {
+        fun create(@BindsInstance context: Context): AppComponent
+    }
 
     fun inject(activity: RegistrationActivity)
 }

--- a/app/src/main/java/com/example/android/dagger/di/StorageModule.kt
+++ b/app/src/main/java/com/example/android/dagger/di/StorageModule.kt
@@ -1,0 +1,13 @@
+package com.example.android.dagger.di
+
+import com.example.android.dagger.storage.SharedPreferencesStorage
+import com.example.android.dagger.storage.Storage
+import dagger.Binds
+import dagger.Module
+
+@Module
+abstract class StorageModule {
+
+    @Binds
+    abstract fun provideStorage(preferencesStorage: SharedPreferencesStorage): Storage
+}

--- a/app/src/main/java/com/example/android/dagger/storage/SharedPreferencesStorage.kt
+++ b/app/src/main/java/com/example/android/dagger/storage/SharedPreferencesStorage.kt
@@ -17,8 +17,9 @@
 package com.example.android.dagger.storage
 
 import android.content.Context
+import javax.inject.Inject
 
-class SharedPreferencesStorage(context: Context) : Storage {
+class SharedPreferencesStorage @Inject constructor(context: Context) : Storage {
 
     private val sharedPreferences = context.getSharedPreferences("Dagger", Context.MODE_PRIVATE)
 


### PR DESCRIPTION
- A Dagger Module is a class that is annotated with @Module.
- Use @Binds to tell Dagger which implementation it needs to use when providing an interface.
- Use @BindsInstance for objects that are constructed outside of the graph (e.g. instances of Context).