### PR TITLE
7-Scoping Subcomponent

### DIFF
--- a/app/src/main/java/com/example/android/dagger/di/ActivityScope.kt
+++ b/app/src/main/java/com/example/android/dagger/di/ActivityScope.kt
@@ -1,0 +1,8 @@
+package com.example.android.dagger.di
+
+import javax.inject.Scope
+
+@Scope
+@MustBeDocumented
+@Retention(value = AnnotationRetention.RUNTIME)
+annotation class ActivityScope

--- a/app/src/main/java/com/example/android/dagger/registration/RegistrationComponent.kt
+++ b/app/src/main/java/com/example/android/dagger/registration/RegistrationComponent.kt
@@ -1,11 +1,13 @@
 package com.example.android.dagger.registration
 
+import com.example.android.dagger.di.ActivityScope
 import com.example.android.dagger.registration.enterdetails.EnterDetailsFragment
 import com.example.android.dagger.registration.termsandconditions.TermsAndConditionsFragment
 import dagger.Component
 import dagger.Subcomponent
 
 @Subcomponent
+@ActivityScope
 interface RegistrationComponent {
 
     @Subcomponent.Factory

--- a/app/src/main/java/com/example/android/dagger/registration/RegistrationViewModel.kt
+++ b/app/src/main/java/com/example/android/dagger/registration/RegistrationViewModel.kt
@@ -16,14 +16,15 @@
 
 package com.example.android.dagger.registration
 
+import com.example.android.dagger.di.ActivityScope
 import com.example.android.dagger.user.UserManager
 import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * RegistrationViewModel is the ViewModel that the Registration flow ([RegistrationActivity]
  * and fragments) uses to keep user's input data.
  */
+@ActivityScope
 class RegistrationViewModel @Inject constructor(val userManager: UserManager) {
 
     private var username: String? = null

--- a/app/src/main/java/com/example/android/dagger/registration/enterdetails/EnterDetailsViewModel.kt
+++ b/app/src/main/java/com/example/android/dagger/registration/enterdetails/EnterDetailsViewModel.kt
@@ -18,6 +18,7 @@ package com.example.android.dagger.registration.enterdetails
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import com.example.android.dagger.di.ActivityScope
 import javax.inject.Inject
 
 private const val MAX_LENGTH = 5
@@ -26,6 +27,7 @@ private const val MAX_LENGTH = 5
  * EnterDetailsViewModel is the ViewModel that [EnterDetailsFragment] uses to
  * obtain to validate user's input data.
  */
+@ActivityScope
 class EnterDetailsViewModel @Inject constructor() {
 
     private val _enterDetailsState = MutableLiveData<EnterDetailsViewState>()


### PR DESCRIPTION
- When a type is marked with a scope annotation, it can only be used by Components that are annotated with the same scope.
- When a Component is marked with a scope annotation, it can only provide types with that annotation or types that have no annotation.
- A subcomponent cannot use a scope annotation used by one of its parent Components.
- If you noticed, the variable registrationComponent is not annotated with @Inject because we're not expecting that variable to be provided by Dagger.