### PR TITLE
8-Refactoring the login flow

### DIFF
--- a/app/src/main/java/com/example/android/dagger/di/AppComponent.kt
+++ b/app/src/main/java/com/example/android/dagger/di/AppComponent.kt
@@ -1,11 +1,9 @@
 package com.example.android.dagger.di
 
 import android.content.Context
+import com.example.android.dagger.login.LoginComponent
 import com.example.android.dagger.main.MainActivity
-import com.example.android.dagger.registration.RegistrationActivity
 import com.example.android.dagger.registration.RegistrationComponent
-import com.example.android.dagger.registration.enterdetails.EnterDetailsFragment
-import com.example.android.dagger.registration.termsandconditions.TermsAndConditionsFragment
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Singleton
@@ -20,6 +18,8 @@ interface AppComponent {
     }
 
     fun registrationComponent(): RegistrationComponent.Factory
+    fun loginComponent(): LoginComponent.Factory
+
     fun inject(activity: MainActivity)
 
 }

--- a/app/src/main/java/com/example/android/dagger/di/AppSubcomponents.kt
+++ b/app/src/main/java/com/example/android/dagger/di/AppSubcomponents.kt
@@ -1,9 +1,10 @@
 package com.example.android.dagger.di
 
+import com.example.android.dagger.login.LoginComponent
 import com.example.android.dagger.registration.RegistrationComponent
 import dagger.Module
 
-@Module(subcomponents = [RegistrationComponent::class])
+@Module(subcomponents = [RegistrationComponent::class, LoginComponent::class])
 class AppSubcomponents {
 
 

--- a/app/src/main/java/com/example/android/dagger/login/LoginActivity.kt
+++ b/app/src/main/java/com/example/android/dagger/login/LoginActivity.kt
@@ -29,18 +29,24 @@ import com.example.android.dagger.main.MainActivity
 import com.example.android.dagger.MyApplication
 import com.example.android.dagger.R
 import com.example.android.dagger.registration.RegistrationActivity
+import javax.inject.Inject
 
 class LoginActivity : AppCompatActivity() {
 
-    private lateinit var loginViewModel: LoginViewModel
+    @Inject
+    lateinit var loginViewModel: LoginViewModel
     private lateinit var errorTextView: TextView
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        (application as MyApplication)
+            .appComponent
+            .loginComponent()
+            .create()
+            .inject(this)
+
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
 
-        // Creates ViewModel and listens for the loginState LiveData
-        loginViewModel = LoginViewModel((application as MyApplication).userManager)
         loginViewModel.loginState.observe(this, Observer<LoginViewState> { state ->
             when (state) {
                 is LoginSuccess -> {

--- a/app/src/main/java/com/example/android/dagger/login/LoginComponent.kt
+++ b/app/src/main/java/com/example/android/dagger/login/LoginComponent.kt
@@ -1,0 +1,16 @@
+package com.example.android.dagger.login
+
+import com.example.android.dagger.di.ActivityScope
+import dagger.Subcomponent
+
+@ActivityScope
+@Subcomponent
+interface LoginComponent {
+
+    @Subcomponent.Factory
+    interface Factory {
+        fun create(): LoginComponent
+    }
+
+    fun inject(activity: LoginActivity)
+}

--- a/app/src/main/java/com/example/android/dagger/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/android/dagger/login/LoginViewModel.kt
@@ -19,12 +19,15 @@ package com.example.android.dagger.login
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.example.android.dagger.user.UserManager
+import javax.inject.Inject
 
 /**
  * LoginViewModel is the ViewModel that [LoginActivity] uses to
  * obtain information of what to show on the screen and handle complex logic.
+ * In this case, LoginViewModel doesn't need to be reused by other classes,
+ * that's why we shouldn't annotate it with @ActivityScope.
  */
-class LoginViewModel(private val userManager: UserManager) {
+class LoginViewModel @Inject constructor(private val userManager: UserManager) {
 
     private val _loginState = MutableLiveData<LoginViewState>()
     val loginState: LiveData<LoginViewState>


### PR DESCRIPTION
- Create a file called LoginComponent.kt in the login package and add the definition of LoginComponent as we did with RegistrationComponent but this time, with Login-related classes.
- In this case, LoginViewModel doesn't need to be reused by other classes, that's why we shouldn't annotate it with @ActivityScope.